### PR TITLE
Autofill ballot election_id

### DIFF
--- a/app/controllers/ballots_controller.rb
+++ b/app/controllers/ballots_controller.rb
@@ -20,7 +20,7 @@ class BallotsController < ApplicationController
 		require_login!
 
 		if !params[:election_id] || !(@election = Election.find(params[:election_id]))
-			if (@currently_open_elections = Election.currently_open_to(current_user)).count > 0
+			if (@currently_open_elections = Election.currently_open).count > 0
 				redirect_to new_ballot_path(params: { election_id: @currently_open_elections.first.id }) and return
 			else
 				redirect_to root_path, notice: "No currently open elections."

--- a/app/controllers/ballots_controller.rb
+++ b/app/controllers/ballots_controller.rb
@@ -20,7 +20,11 @@ class BallotsController < ApplicationController
 		require_login!
 
 		if !params[:election_id] || !(@election = Election.find(params[:election_id]))
-			redirect_to root_path, notice: "Missing election id, can't show you a ballot if you don't do that..."
+			if (@currently_open_elections = Election.currently_open_to(current_user)).count > 0
+				redirect_to new_ballot_path(params: { election_id: @currently_open_elections.first.id }) and return
+			else
+				redirect_to root_path, notice: "No currently open elections."
+			end
 		end
 
 		ensure_not_voted_yet!

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -3,6 +3,12 @@ require 'date'
 class Election < ApplicationRecord
 	has_many :positions, dependent: :destroy
 
+	def self.currently_open
+		self.select do |election|
+			election.is_open?
+		end
+	end
+
 	def self.currently_open_to(user)
 		return self.all if user && user.is_admin?
 


### PR DESCRIPTION
I don't know if I like this behavior, especially since #31 basically covered this case.  Now any requests to `/ballots/new` will get a `election_id` param tacked on through a redirect back to the url with the param tacked on.

As always, open to feedback.

Closes #18.