### PR TITLE
Don't redirect to new ballot url

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,5 @@
 class HomeController < ApplicationController
 	def show
 		@votable_elections = Election.currently_open_to(@current_user)
-
-		if @votable_elections.count == 1 && current_user && !current_user.is_admin?
-			redirect_to new_ballot_url(params: {election_id: @votable_elections.first.id})
-		end
   end
 end


### PR DESCRIPTION
This behavior was a bit dangerous.  We can always bring it back, but it was causing some infinite redirects which is not very good.